### PR TITLE
Fix selects page

### DIFF
--- a/_posts/2023-09-25-selects.md
+++ b/_posts/2023-09-25-selects.md
@@ -17,6 +17,8 @@ This is the most basic select menu, it allows the user to select from a list of 
 
 **Example:**
 {% highlight python %}
+from typing import Any
+
 import discord
 from discord.ui import Select
 
@@ -33,7 +35,7 @@ class FruitSelect(Select):
             ]
         )
 
-    async def callback(self, interaction: discord.Interaction) -> None:
+    async def callback(self, interaction: discord.Interaction) -> Any:
         selected_fruit: str = self.values[0]
         await interaction.response.send_message(
             f"{interaction.user.mention}'s favorite fruit is {selected_fruit}!"
@@ -63,6 +65,8 @@ from discord.ui import UserSelect
 {% endhighlight %}
 And [`values`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.ui.UserSelect.values) is a list of [`discord.Member`](https://discordpy.readthedocs.io/en/latest/api.html#member) or [`discord.User`](https://discordpy.readthedocs.io/en/latest/api.html#user) objects:
 {% highlight python %}
+from typing inport Any
+
 async def callback(self, interaction: discord.Interaction) -> Any:
     users: List[Union[discord.Member, discord.User]] = self.values
     selected_users = [
@@ -83,6 +87,8 @@ from discord.ui import RoleSelect
 {% endhighlight %}
 And [`values`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.ui.RoleSelect.values) is a list of [`discord.Role`](https://discordpy.readthedocs.io/en/latest/api.html#role) objects:
 {% highlight python %}
+from typing inport Any
+
 async def callback(self, interaction: discord.Interaction) -> Any:
     roles: List[discord.Role] = self.values
     selected_roles = [
@@ -104,6 +110,8 @@ from discord.ui import MentionableSelect
 
 And [`values`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.ui.MentionableSelect.values) is a list of [`discord.Member`](https://discordpy.readthedocs.io/en/latest/api.html#member), [`discord.User`](https://discordpy.readthedocs.io/en/latest/api.html#user) and [`discord.Role`](https://discordpy.readthedocs.io/en/latest/api.html#role) objects:
 {% highlight python %}
+from typing inport Any
+
 async def callback(self, interaction: discord.Interaction) -> Any:
     mentionables: List[Union[discord.Member, discord.User, discord.Role]] = self.values
     selected_users = [
@@ -131,12 +139,13 @@ This is a select menu that allows the user to select from a list of channels in 
 Code is mostly the same as the example above, except we use `ChannelSelect` instead of `Select` and we can use the `channel_types` kwarg to limit the type of channels shown, all channels are shown by default:
 {% highlight python %}
 from discord import ChannelType
-from discord.app_commands import AppCommandChannnel, AppCommandThread
+from discord.app_commands import AppCommandChannel, AppCommandThread
 from discord.ui import ChannelSelect
 {% endhighlight %}
 
-And [`values`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.ui.ChannelSelect.values) is a list of [`discord.AppCommandChannnel`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#appcommandchannel) or [`discord.AppcommandThread`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#appcommandthread) objects:
+And [`values`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#discord.ui.ChannelSelect.values) is a list of [`discord.AppCommandChannel`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#appcommandchannel) or [`discord.AppcommandThread`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#appcommandthread) objects:
 {% highlight python %}
+from typing inport Any
 
 class ChannelsSelector(ChannelSelect):
     def __init__(self):
@@ -145,15 +154,15 @@ class ChannelsSelector(ChannelSelect):
             # limit the type of channels shown to text, voice and threads
             channel_types=[ChannelType.text, ChannelType.voice, ChannelType.thread]
 
-async def callback(self, interaction: discord.Interaction) -> Any:
-    channels: List[Union[AppCommandChannnel, AppCommandThread]] = self.values
-    selected_channels = [
-        f"Name: {channel.name}, ID: {channel.id}"
-        for channel in channels
-    ]
-    await interaction.response.send_message(
-        f"{interaction.user.mention} selected the following channels:\n" + "\n".join(selected_channels)
-    )
+    async def callback(self, interaction: discord.Interaction) -> Any:
+        channels: List[Union[AppCommandChannel, AppCommandThread]] = self.values
+        selected_channels = [
+            f"Name: {channel.name}, ID: {channel.id}"
+            for channel in channels
+        ]
+        await interaction.response.send_message(
+            f"{interaction.user.mention} selected the following channels:\n" + "\n".join(selected_channels)
+        )
 {% endhighlight %}
 
 ## default_values
@@ -162,7 +171,7 @@ async def callback(self, interaction: discord.Interaction) -> Any:
 This was briefly mentioned above, but you can specify the options that should be selected by default using the `default_values` kwarg.
 
 The kwarg takes a list of objects, the type of which depends on the type of select menu.
-There is also special class for it called `SelectDefaultValue` which takes the `id` of a user, role of channel and the `type` of the object.
+There is also special class for it called [`SelectDefaultValue`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#selectdefaultvalue) which takes the `id` of a user, role of channel and the `type` of the object.
 
 {% highlight python %}
 import discord

--- a/_posts/2023-09-25-selects.md
+++ b/_posts/2023-09-25-selects.md
@@ -171,7 +171,7 @@ class ChannelsSelector(ChannelSelect):
 This was briefly mentioned above, but you can specify the options that should be selected by default using the `default_values` kwarg.
 
 The kwarg takes a list of objects, the type of which depends on the type of select menu.
-There is also special class for it called [`SelectDefaultValue`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#selectdefaultvalue) which takes the `id` of a user, role of channel and the `type` of the object.
+There is also special class for it called [`SelectDefaultValue`](https://discordpy.readthedocs.io/en/latest/interactions/api.html#selectdefaultvalue) which takes the `id` of a user, role of channel and the [`type`](https://discordpy.readthedocs.io/en/latest/api.html#discord.SelectDefaultValueType) of the object.
 
 {% highlight python %}
 import discord


### PR DESCRIPTION
- Fix typo for App command channel
- Add import for `typing.Any`
- Fix indents for ChannelSelect
- Hyperlink SelectDefaultValue
- Hyperlink to type of SelectDefaultValue 