### PR TITLE
Fix missing ')' in __init__

### DIFF
--- a/_posts/2023-09-25-selects.md
+++ b/_posts/2023-09-25-selects.md
@@ -360,12 +360,11 @@ class ModalWithSelect(ui.Modal):
         if not reason:
             response = f"Your favorite fruit is {chosen_fruit} but *you didn't tell us why :(*"
        else:
-           response = f"Your favorite fruit is {chosen_fruit} because {reason}"
+            response = f"Your favorite fruit is {chosen_fruit} because {reason}"
 
         await interaction.response.send_message(response)
 
 
 
 {% endhighlight %}
-
 

--- a/_posts/2023-09-25-selects.md
+++ b/_posts/2023-09-25-selects.md
@@ -367,4 +367,3 @@ class ModalWithSelect(ui.Modal):
 
 
 {% endhighlight %}
-

--- a/_posts/2023-09-25-selects.md
+++ b/_posts/2023-09-25-selects.md
@@ -188,6 +188,7 @@ class ChannelsSelector(ChannelSelect):
             placeholder="Select a channel...",
             # limit the type of channels shown to text, voice and threads
             channel_types=[ChannelType.text, ChannelType.voice, ChannelType.thread]
+        )
 
     async def callback(self, interaction: discord.Interaction) -> Any:
         channels: list[AppCommandChannel | AppCommandThread] = self.values
@@ -357,12 +358,13 @@ class ModalWithSelect(ui.Modal):
         
         # reason is optional so we can handle that here
         if not reason:
-            reason = "*you didn't tell us why :(*"
+            response = f"Your favourite fruit is {chosen_furit} but *you didn't tell us why :(*"
+       else:
+           response = f"Your favorite fruit is {chosen_fruit} because {reason}"
 
-        await interaction.response.send_message(
-            f"Your favorite fruit is {chosen_fruit} because {reason}"
-        )
+        await interaction.response.send_message(response)
 
 
 
 {% endhighlight %}
+

--- a/_posts/2023-09-25-selects.md
+++ b/_posts/2023-09-25-selects.md
@@ -358,7 +358,7 @@ class ModalWithSelect(ui.Modal):
         
         # reason is optional so we can handle that here
         if not reason:
-            response = f"Your favourite fruit is {chosen_furit} but *you didn't tell us why :(*"
+            response = f"Your favorite fruit is {chosen_fruit} but *you didn't tell us why :(*"
        else:
            response = f"Your favorite fruit is {chosen_fruit} because {reason}"
 
@@ -367,4 +367,5 @@ class ModalWithSelect(ui.Modal):
 
 
 {% endhighlight %}
+
 


### PR DESCRIPTION
I also ended up updating:
```py
if not reason:
    reason = "*you didn't tell us why :(*"

await interaction.response.send_message(
    f"Your favorite fruit is {chosen_fruit} because {reason}"
)
```
Cuz "`Your favorite fruit is apple because you didn't tell us why :(`" is not sound, 
instead it's now "`Your favorite fruit is apple but you didn't tell us why :(`".